### PR TITLE
force tracking mode to cookies

### DIFF
--- a/gerenciador-final/WebContent/WEB-INF/web.xml
+++ b/gerenciador-final/WebContent/WEB-INF/web.xml
@@ -5,11 +5,11 @@
 	id="WebApp_ID" version="3.0">
 	<display-name>gerenciador</display-name>
 
-  <session-config>
-    <tracking-mode>COOKIE</tracking-mode>
-  </session-config>
+	<session-config>
+		<tracking-mode>COOKIE</tracking-mode>
+	</session-config>
 
-  <welcome-file-list>
+	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 		<welcome-file>index.jsp</welcome-file>
 	</welcome-file-list>

--- a/gerenciador-final/WebContent/WEB-INF/web.xml
+++ b/gerenciador-final/WebContent/WEB-INF/web.xml
@@ -4,9 +4,12 @@
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
 	id="WebApp_ID" version="3.0">
 	<display-name>gerenciador</display-name>
-	
-	
-	<welcome-file-list>
+
+  <session-config>
+    <tracking-mode>COOKIE</tracking-mode>
+  </session-config>
+
+  <welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 		<welcome-file>index.jsp</welcome-file>
 	</welcome-file-list>

--- a/gerenciador/WebContent/WEB-INF/web.xml
+++ b/gerenciador/WebContent/WEB-INF/web.xml
@@ -4,8 +4,12 @@
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
 	id="WebApp_ID" version="3.0">
 	<display-name>gerenciador</display-name>
+
+	<session-config>
+		<tracking-mode>COOKIE</tracking-mode>
+	</session-config>
 	
-	
+
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 		<welcome-file>index.jsp</welcome-file>

--- a/gerenciador/WebContent/WEB-INF/web.xml
+++ b/gerenciador/WebContent/WEB-INF/web.xml
@@ -8,7 +8,6 @@
 	<session-config>
 		<tracking-mode>COOKIE</tracking-mode>
 	</session-config>
-	
 
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>


### PR DESCRIPTION
Comportamento padrão do TomCat 8 é utilizar o tracking pela URL, adicionando parâmetros para fazer o tracking de session por cookies! 

[Discussão aberta](https://www.alura.com.br/course/servlet-3-e-fundamentos-web/discussions/673165).
